### PR TITLE
feat: prohibit pushing to trigger branch

### DIFF
--- a/src/set-tokens.ts
+++ b/src/set-tokens.ts
@@ -70,6 +70,7 @@ Host github
     core.warning(
       'GITHUB_TOKEN does not support to trigger the GitHub Pages build event on a public repository.'
     );
+    core.debug(JSON.stringify(github.context.payload));
     if (inps.ExternalRepository) {
       core.error(
         'GITHUB_TOKEN does not support to push to an external repository'


### PR DESCRIPTION
- トリガーブランチへの push を禁止 (external を考慮)
- public repo GITHUB_TOKEN warning